### PR TITLE
Changed Piston Qualities

### DIFF
--- a/src/Subsystems/Piston.cpp
+++ b/src/Subsystems/Piston.cpp
@@ -9,14 +9,14 @@ Piston::Piston() : Subsystem("Piston")
 
 void Piston::Extend()
 {
-	s0->Set(true);
-	s1->Set(false);
+	s0->Set(false);
+	s1->Set(true);
 	isOpen = true;
 }
 
 void Piston::Retract()
 {
 	isOpen = false;
-	s0->Set(false);
-	s1->Set(true);
+	s0->Set(true);
+	s1->Set(false);
 }


### PR DESCRIPTION
Changed s0 on extend to false, and s1 on extend to true. This allows for
it to correspond with the Function name. This has also been done for
retract with the opposite settings.
